### PR TITLE
Hotfix/sponsors endless loading

### DIFF
--- a/src/sponsorController.php
+++ b/src/sponsorController.php
@@ -46,6 +46,9 @@ class UserController extends BaseController
         if(isset($res["boxMsgs"])) $data["boxMsgs"] = $res["boxMsgs"];
         if(isset($res["form"]["error"])) $data["form"]["error"] = $res["form"]["error"];
 
+        if(isset($res["boxMsgs"])) $data["boxMsgs"] = $res["boxMsgs"];
+        if(isset($res["form"]["error"])) $data["form"]["error"] = $res["form"]["error"];
+
         $this->getLogin($data);
     }
 }


### PR DESCRIPTION
# Description

This merge request seeks to integrate the fix for the endless loading issue on the Sponsors page from the hotfix branch into the develop branch. This bug was preventing users from successfully submitting the subscription form.

Fixes # (issue)

* Fix Endless Loading Issue: Addressed the bug causing the endless loading spinner on form submission in the Sponsors page. The form should now submit properly, providing a success message to the user upon completion.

# How Has This Been Tested?

* Sponsors Page: Navigate to the Sponsors page and try submitting the subscription form. Ensure that the form submits successfully, with no endless loading spinner, and that a success message is displayed upon submission.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes